### PR TITLE
Added missing hyphen for apt-get

### DIFF
--- a/docs/mining/compiling/basiccompilation.mdx
+++ b/docs/mining/compiling/basiccompilation.mdx
@@ -70,8 +70,8 @@ wsl --set-default-version 2
 
 ```bash
 #Update and Upgrade ubuntu:
-sudo apt get update
-sudo apt get upgrade
+sudo apt-get update
+sudo apt-get upgrade
 
 #Download build essentials:
 sudo apt-get install build-essential libssl-dev libcurl4-openssl-dev libjansson-dev libgmp-dev automake zlib1g-dev git


### PR DESCRIPTION
The hyphen was missing between apt and get in the Compiling using WSL / Ubuntu 20.04 LTS section.